### PR TITLE
Fix tsconfig.json to include ts files under 'tests'

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,6 @@
   },
   "include": [
     "src/**/*.ts",
-    "test/**/*.ts"
+    "tests/**/*.ts"
   ]
 }


### PR DESCRIPTION
`tsconfig.json` specifies the `test` directory in the `include` property, but the correct directory name should be `tests`. This PR fixes the issue.