### PR TITLE
Update node versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12, 14, 16, 17]
+        node-version: [14, 16, 18]
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v2


### PR DESCRIPTION
This patch updates the node versions from [12, 14, 16, 17] to [14, 16, 18].

This matches the BudouX change[1].

[1] https://github.com/google/budoux/pull/72