### PR TITLE
Fix `DocumentApplier.apply` to use the attached document

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dist": "ts-node scripts/package.ts -d dist --js build/bundle",
     "prezip": "npm run clean && npm run dist",
     "zip": "ts-node scripts/package.ts -d dist --zip budoux.zip",
-    "bundle:test": "esbuild build/tests/index.browser.js --outdir=build/bundle --bundle --minify --sourcemap",
+    "bundle:test": "esbuild build/tests/index.browser.js --outdir=build/bundle --bundle --sourcemap",
     "pretest": "npm run tsc:es && npm run bundle:test",
     "test": "karma start --single-run",
     "lint": "gts lint",

--- a/src/content.ts
+++ b/src/content.ts
@@ -16,4 +16,4 @@
 
 import {DocumentApplier} from './document_applier';
 
-DocumentApplier.fromDocument(document).applyToDocument();
+DocumentApplier.fromDocument(document).apply();

--- a/src/document_applier.ts
+++ b/src/document_applier.ts
@@ -28,15 +28,21 @@ function logDebug(...args: any[]) {
 const className = 'BudouX';
 
 export class DocumentApplier {
-  static fromDocument(document: Document) {
+  private document: Document;
+
+  constructor(document: Document) {
+    this.document = document;
+  }
+
+  static fromDocument(document: Document): DocumentApplier {
     // @ts-expect-error Use a dynamic property of the document.
     let docApplier = document.budouX;
     logDebug('fromDocument: ', docApplier);
     if (!docApplier) {
-      docApplier = new DocumentApplier();
+      docApplier = new DocumentApplier(document);
       // @ts-expect-error Use a dynamic property of the document.
       document.budouX = docApplier;
-      DocumentApplier.defineClassAs(document, className);
+      docApplier.defineClassAs(className);
     }
     return docApplier;
   }
@@ -46,13 +52,14 @@ export class DocumentApplier {
    * @param document The document to append to.
    * @param className The CSS class name.
    */
-  static defineClassAs(document: Document, className: string): void {
+  private defineClassAs(className: string): void {
+    const document = this.document;
     const style = document.createElement('style');
     style.textContent = `.${className} { word-break: keep-all; overflow-wrap: anywhere; }`;
     document.head.appendChild(style);
   }
 
-  async applyToDocument() {
+  async apply() {
     const parser = loadDefaultJapaneseParser();
     const applier = new HTMLProcessor(parser);
     applier.className = className;
@@ -71,6 +78,7 @@ export class DocumentApplier {
       });
     }
 
+    const document = this.document;
     await this.waitForDOMContentLoaded(document);
 
     applier.applyToElement(document.body);

--- a/tests/test_document_applier.ts
+++ b/tests/test_document_applier.ts
@@ -36,3 +36,14 @@ describe('DocumentApplier.fromDocument', () => {
     expect(element.textContent).toMatch(/^\.BudouX {.*}$/);
   });
 });
+
+describe('DocumentApplier.apply', () => {
+  it('should apply', async () => {
+    const doc = documentFromString('<div>今日は良い天気です。</div>');
+    const applier = DocumentApplier.fromDocument(doc);
+    await applier.apply();
+    expect(doc.body.innerHTML).toEqual(
+      '<div class="BudouX">今日は\u200B良い\u200B天気です。</div>'
+    );
+  });
+});


### PR DESCRIPTION
This patch fixes `DocumentApplier.apply` to apply to its attached document, instead of the global `document` variable.

This patch also adds a test.